### PR TITLE
Change which can specify rebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,23 @@
 .PHONY: deps test
 
+REBAR := ./rebar
 all:
-	@./rebar update-deps
-	@./rebar get-deps
-	@./rebar compile
-	@./rebar xref skip_deps=true
-	@./rebar eunit skip_deps=true
+	@$(REBAR) update-deps
+	@$(REBAR) get-deps
+	@$(REBAR) compile
+	@$(REBAR) xref skip_deps=true
+	@$(REBAR) eunit skip_deps=true
 compile:
-	@./rebar compile skip_deps=true
+	@$(REBAR) compile skip_deps=true
 xref:
-	@./rebar xref skip_deps=true
+	@$(REBAR) xref skip_deps=true
 eunit:
-	@./rebar eunit skip_deps=true
+	@$(REBAR) eunit skip_deps=true
 clean:
-	@./rebar clean skip_deps=true
+	@$(REBAR) clean skip_deps=true
 distclean:
-	@./rebar delete-deps
-	@./rebar clean
+	@$(REBAR) delete-deps
+	@$(REBAR) clean
 qc:
-	@./rebar qc skip_deps=true
+	@$(REBAR) qc skip_deps=true
 


### PR DESCRIPTION
Some users may use not rebar attached but installed in the system.
This changes which can specify rebar.

Signed-off-by: Nobuhiro Iwamatsu iwamatsu@debian.org
