### PR TITLE
Add "no node specified" error

### DIFF
--- a/src/leo_manager_controller.erl
+++ b/src/leo_manager_controller.erl
@@ -41,7 +41,7 @@
 -define(ERROR_COULD_NOT_ATTACH_NODE, "could not attach a node").
 -define(ERROR_COULD_NOT_DETACH_NODE, "could not detach a node").
 -define(ERROR_COMMAND_NOT_FOUND,     "command not exist").
--define(ERROR_NO_NODE_SPECIFIED, "no nodes specified").
+-define(ERROR_NO_NODE_SPECIFIED, "no node specified").
 
 
 %%----------------------------------------------------------------------


### PR DESCRIPTION
\Now, leofs console raises "command not exist" error when no node is specified in detach, resume, suspend and so on.

-\- current --
\suspend
[ERROR] command not exist
----

\I think the behavior is confusing.
\Therefore, I added a new err "No node specified".

-\- proposed --
\suspend
[ERROR] no nodes specified
----
