### PR TITLE
Mod version number in schema

### DIFF
--- a/priv/leo_manager_0.schema
+++ b/priv/leo_manager_0.schema
@@ -97,7 +97,7 @@
  "leo_manager.system_version",
  [
   {datatype, string},
-  {default, "1.2.4"}
+  {default, "1.2.5"}
  ]}.
 
 %% @doc Mode of Manager: [master|slave]

--- a/priv/leo_manager_1.schema
+++ b/priv/leo_manager_1.schema
@@ -97,7 +97,7 @@
  "leo_manager.system_version",
  [
   {datatype, string},
-  {default, "1.2.4"}
+  {default, "1.2.5"}
  ]}.
 
 %% @doc Mode of Manager: [master, slave]


### PR DESCRIPTION
For 1.2.5 version, system_version number was wrong.
I modified the number of version from 1.2.4 to 1.2.5.