### PR TITLE
make comment-out style even between leo_manager_0.conf and leo_manager_1.conf

### DIFF
--- a/priv/leo_manager_1.conf
+++ b/priv/leo_manager_1.conf
@@ -161,4 +161,4 @@ erlang.max_ets_tables = 256000
 process_limit = 1048576
 
 ## Path of SNMP-agent configuration
-snmp_conf = ./snmp/snmpa_manager_1/leo_manager_snmp
+## snmp_conf = ./snmp/snmpa_manager_1/leo_manager_snmp

--- a/priv/leo_manager_1.schema
+++ b/priv/leo_manager_1.schema
@@ -521,5 +521,5 @@
  "snmp_conf",
  "vm_args.-config",
  [
-  {default, "./snmp/snmpa_manager_0/leo_manager_snmp"}
+  {default, "./snmp/snmpa_manager_1/leo_manager_snmp"}
  ]}.


### PR DESCRIPTION
I found the difference comment-out style as following.
In leo_manager_0.conf
```
## Path of SNMP-agent configuration
## snmp_conf = ./snmp/snmpa_manager_0/leo_manager_snmp
```

In leo_manager_1.conf
```
## Path of SNMP-agent configuration
snmp_conf = ./snmp/snmpa_manager_0/leo_manager_snmp
```

I modified to make it same style by adding "## " comment in leo_manager_1.conf.