### PR TITLE
Added Gen NFS Mount Key API

### DIFF
--- a/src/leo_manager_api.erl
+++ b/src/leo_manager_api.erl
@@ -74,7 +74,7 @@
          synchronize/1, synchronize/2, synchronize/3,
          set_endpoint/1, delete_endpoint/1,
          add_bucket/2, add_bucket/3, delete_bucket/2, update_bucket/1,
-         update_acl/3
+         update_acl/3, gen_nfs_mnt_key/3
         ]).
 
 -export([join_cluster/2,
@@ -2351,6 +2351,8 @@ update_acl(?CANNED_ACL_AUTHENTICATED_READ = Permission, AccessKey, Bucket) ->
 update_acl(_,_,_) ->
     {error, ?ERROR_INVALID_ARGS}.
 
+gen_nfs_mnt_key(Bucket, AccessKey, IP) ->
+    leo_s3_bucket:gen_nfs_mnt_key(Bucket, AccessKey, IP).
 
 %% @doc RPC call for Gateway-nodes
 %% @private


### PR DESCRIPTION
## Description

Added `leo_manager_api:gen_nfs_mnt_key/3` for `leo_gateway` to request NFS Mount Key
## Related Issue

https://github.com/leo-project/leofs/issues/436
## Related PR

https://github.com/leo-project/leo_manager/pull/16
https://github.com/leo-project/leo_gateway/pull/43
